### PR TITLE
short country name fix

### DIFF
--- a/data/countries_info.csv
+++ b/data/countries_info.csv
@@ -40,7 +40,6 @@
 42,Cambodia,The Kingdom of Cambodia,UN member state,KH,KHM,116,ISO 3166-2:KH,.kh
 43,Cameroon,The Republic of Cameroon,UN member state,CM,CMR,120,ISO 3166-2:CM,.cm
 44,Canada,Canada,UN member state,CA,CAN,124,ISO 3166-2:CA,.ca
-46,"Caribbean Netherlands – See Bonaire, Sint Eustatius and Saba.",,,,,,,
 47,Cayman Islands ,The Cayman Islands,United Kingdom,KY,CYM,136,ISO 3166-2:KY,.ky
 48,Central African Republic ,The Central African Republic,UN member state,CF,CAF,140,ISO 3166-2:CF,.cf
 49,Chad,The Republic of Chad,UN member state,TD,TCD,148,ISO 3166-2:TD,.td


### PR DESCRIPTION
Various name changes in the data for better usability.

- fix: More intuitive, commonly known short anmes for some countries. Distinguish North and South Korea
- fix: Short name for UK
- chore: Remove territory without ISO code
