### PR TITLE
fix(env): use env var pg port instead if hardcoded value

### DIFF
--- a/api/country_data_api.py
+++ b/api/country_data_api.py
@@ -33,16 +33,17 @@ app.add_middleware(
 ## database connection
 
 host = os.environ['POSTGRES_HOST']
+port = os.environ.get('POSTGRES_PORT', 5432)
 dbname = os.environ['POSTGRES_DB']
 user = os.environ['POSTGRES_USER']
 password = os.environ['POSTGRES_PASSWORD']
 
 
 sslmode = "require"
-    
+
 # Construct connection string
 print(f"USING ENV: {os.environ['ENV']}")
-conn_string = f"postgresql+psycopg://{user}:{password}@{host}:{5432}/{dbname}"
+conn_string = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{dbname}"
 
 # Cet up connecttion
 print(f"Connecting to: {conn_string}")

--- a/taro/pipeline.py
+++ b/taro/pipeline.py
@@ -368,17 +368,18 @@ if __name__ == "__main__":
     # Connection string info
     
     host = os.environ['POSTGRES_HOST']
+    port = os.environ.get('POSTGRES_PORT', 5432)
     dbname = os.environ['POSTGRES_DB']
-    
+
     # Use tf vars if not local dev env
     user = os.environ['POSTGRES_USER']
     password = os.environ['POSTGRES_PASSWORD']
 
-    
+
     sslmode = "require"
-    
+
     # Construct connection string
-    conn_string = f"postgresql+psycopg://{user}:{password}@{host}:{5432}/{dbname}"
+    conn_string = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{dbname}"
     
     print(conn_string)
     

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,11 +12,12 @@ elif os.environ['ENV'] == 'test':
     conn_string = 'postgresql://postgres:password@localhost/postgres'
 else:
     host = "taro-server.postgres.database.azure.com"
+    port = os.environ.get('POSTGRES_PORT', 5432)
     dbname = "taro-db"
     user = "postgres"
     password = os.environ['POSTGRES_PASSWORD']
     sslmode = "require"
-    conn_string = f"postgresql+psycopg://{user}:{password}@{host}:{5432}/{dbname}"
+    conn_string = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{dbname}"
 
 
 db = create_engine(conn_string)


### PR DESCRIPTION
the pipeline and api were using a hardcoded pg port, ignoring the env var. Now fixed